### PR TITLE
cmake: Use CTest for test management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,12 @@ option(LIBIRM_BUILD_32_BITS "Enable 32 bits build" OFF)
 
 include(build-system/build-system.cmake)
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  include(CTest)
+endif()
+
 add_subdirectory(lib)
-add_subdirectory(tests)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
Only configure and build tests when this is the primary project. Avoids
having test targets show up inside other projects when this library is
included as a dependency.

Without this we can see a target irm-tests show up inside the mull cmake build.