### PR TITLE
cmake: Apply -fno-rtti conditionally

### DIFF
--- a/build-system/compilation-flags.cmake
+++ b/build-system/compilation-flags.cmake
@@ -6,7 +6,11 @@ if (LIBIRM_BUILD_32_BITS)
   set (CMAKE_CXX_FLAGS -m32 ${CMAKE_CXX_FLAGS})
 endif()
 
-set (LIBIRM_CMAKE_CXX_FLAGS -fno-rtti -Wall -Werror)
+set (LIBIRM_CMAKE_CXX_FLAGS -Wall -Werror)
+if (NOT LLVM_ENABLE_RTTI)
+  list(APPEND LIBIRM_CMAKE_CXX_FLAGS -fno-rtti)
+endif()
+
 set (LIBIRM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 if(MULL_INTEGRATION)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fembed-bitcode")


### PR DESCRIPTION
The packaged LLVM libs in Fedora are compiled with RTTI, which causes linking issues for missing typeinfo for irm:: classes in the Mull unit tests when building libirm with -fno-rtti.
The LLVM config cmake script that is installed with the libs will set LLVM_ENABLE_RTTI when LLVM was built with RTTI so we should follow that setting.