### PR TITLE
bugfix: Add missing replaceAllUsesWith call for IntrinsicReplacement

### DIFF
--- a/lib/IntrinsicReplacement.cpp
+++ b/lib/IntrinsicReplacement.cpp
@@ -48,5 +48,6 @@ void IntrinsicReplacement::mutate(llvm::Instruction *instruction) {
 
   auto call = llvm::CallInst::Create(replacement, arguments, "");
   call->insertAfter(instruction);
+  instruction->replaceAllUsesWith(call);
   instruction->eraseFromParent();
 }

--- a/tests/Mutations/InstrinsicReplacementTests.cpp
+++ b/tests/Mutations/InstrinsicReplacementTests.cpp
@@ -64,12 +64,13 @@ TEST(IntrinsicReplacement, mutate) {
   auto op2 = llvm::ConstantInt::get(intrinsicType, 40, false);
 
   auto callSad = llvm::CallInst::Create(sadd, { op1, op2 }, "", basicBlock);
-
+  auto resultUse = llvm::ExtractValueInst::Create(callSad, { 1 }, "", basicBlock);
   sadd_with_overflowTossub_with_overflow mutator;
   mutator.mutate(callSad);
 
   auto ssub = llvm::dyn_cast<llvm::IntrinsicInst>(&basicBlock->front());
 
+  ASSERT_EQ(resultUse->getAggregateOperand(), ssub);
   ASSERT_NE(ssub, nullptr);
   ASSERT_EQ(ssub->getIntrinsicID(), llvm::Intrinsic::ssub_with_overflow);
   ASSERT_EQ(ssub->getOperand(0), op1);


### PR DESCRIPTION
I found that `IntrinsicReplacement` forgot to call `replaceAllUsesWith` while mutation. 